### PR TITLE
feat(slack-channel): add channel for release-comms

### DIFF
--- a/communication/slack-config/sig-release/config.yaml
+++ b/communication/slack-config/sig-release/config.yaml
@@ -1,6 +1,7 @@
 channels:
   - name: sig-release
   - name: release-ci-signal
+  - name: release-comms
   - name: release-management
     id: CJH2GBF7Y
   - name: release-notes


### PR DESCRIPTION
To date, the Comms team have created DM groups with the lead and shadows for each release.

This channel would allow for process, questions, and knowledge to be passed on from each release and also allow any conversations within the team to be consumable by any casual observers with an interest in future participation.

FYI @castrojo @onlydole